### PR TITLE
V1.2.1

### DIFF
--- a/ops/generate.py
+++ b/ops/generate.py
@@ -80,7 +80,9 @@ def generate_genepanels(session, meta, hgnc_data: dict):
     # get the gemini names and associated genes and panels ids
     cis = session.query(
         ci_tb.c.gemini_name, ci2panels_tb.c.panel_id
-    ).join(ci2panels_tb).all()
+    ).join(
+        ci2panels_tb, ci_tb.c.id == ci2panels_tb.c.clinical_indication_id
+    ).all()
 
     gemini2genes = get_clinical_indication_through_genes(
         session, meta, cis, hgnc_data
@@ -256,7 +258,9 @@ def generate_manifest(session, meta, gemini_dump: str, hgnc_data: dict):
     # get the gemini names and associated genes and panels ids
     ci_in_manifest = session.query(
         ci_tb.c.gemini_name, ci2panels_tb.c.panel_id
-    ).join(ci2panels_tb).filter(
+    ).join(
+        ci2panels_tb, ci_tb.c.id == ci2panels_tb.c.clinical_indication_id
+    ).filter(
         ci_tb.c.gemini_name.in_(uniq_used_panels)
     ).all()
 

--- a/ops/mod_db.py
+++ b/ops/mod_db.py
@@ -132,7 +132,7 @@ def import_new_g2t(path_to_g2t_file: str):
                 f"Created gene and feature for {gene}: {new_gene}, "
                 f"{new_feature}"
             )
-        output_to_loggers(msg, "info", CONSOLE, MOD_DB)
+            output_to_loggers(msg, "info", CONSOLE, MOD_DB)
 
         for transcript, statuses in g2t_data[gene].items():
             refseq, version = transcript.split(".")
@@ -170,7 +170,7 @@ def import_new_g2t(path_to_g2t_file: str):
                     transcript_id=new_tx.id, clinical_transcript=clinical
                 )
 
-                if not tx_created or not g2t_created:
+                if (tx_created and not g2t_created) or (not tx_created and g2t_created):
                     msg = (
                         "One of the following row already existed: "
                         f"{new_tx} {tx_created} | "
@@ -178,7 +178,7 @@ def import_new_g2t(path_to_g2t_file: str):
                         "Please check that there is no underlying issues."
                     )
                     output_to_loggers(msg, "warning", CONSOLE, MOD_DB)
-                else:
+                elif tx_created and g2t_created:
                     msg = (
                         f"The following objects have been created: {new_tx}, "
                         f"{new_g2t}"
@@ -270,8 +270,7 @@ def import_bespoke_panel(panel_form: str):
                         f"Feature for gene {new_feature.gene_id} created: "
                         f"{new_feature.id}"
                     )
-
-                output_to_loggers(msg, "info", CONSOLE, MOD_DB)
+                    output_to_loggers(msg, "info", CONSOLE, MOD_DB)
 
                 # create panel feature link
                 panel_feature_link = PanelFeatures.objects.get_or_create(
@@ -286,8 +285,7 @@ def import_bespoke_panel(panel_form: str):
 
             if ci_created:
                 msg = f"Clinical indication {new_ci.name} created: {new_ci.id}"
-
-            output_to_loggers(msg, "info", CONSOLE, MOD_DB)
+                output_to_loggers(msg, "info", CONSOLE, MOD_DB)
 
             # create clinical indication panel link
             ci_panel_link = ClinicalIndicationPanels.objects.get_or_create(

--- a/ops/utils.py
+++ b/ops/utils.py
@@ -1034,9 +1034,9 @@ def gather_clinical_indication_data_django_json(
                 )
             else:
                 # it's a gene panel name thingy (HGNC:[0-9]_SG)
-                gene_panel_name = f"{panel}_SG"
+                gene_panel_name = f"{panel}_SG_panel"
                 panel_pk = get_existing_object_pk(
-                    panel_json, "panelapp_id", gene_panel_name
+                    panel_json, "name", gene_panel_name
                 )
 
             pk_dict["clinind_panels"] += 1
@@ -1146,7 +1146,7 @@ def add_feature(feature_pk: int, feature_type_pk: int, **links):
 
 def add_panel_feature(
     pk: int, panel_pk: int, version: str, feature_pk: int,
-    description: str = None
+    description: str = ""
 ):
     """ Return a panel feature object
 


### PR DESCRIPTION
- `ci_tb.c.id == ci2panels_tb.c.clinical_indication_id` this is necessary with the change of db structure. Why? I do not know
- `output to loggers` moving because msgs were getting printed at every iteration
- `f"{panel}_SG_panel"` because those single gene panels do not have a panelapp id anymore which i was using to get the primary key of the panel row. So i'm using their names instead
- `if (tx_created and not g2t_created) or (not tx_created and g2t_created):` more thorough checking if the tx are created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/panel_ops/50)
<!-- Reviewable:end -->
